### PR TITLE
Fix: Replace np.product with alternative for compatibility with NumPy 1.25+

### DIFF
--- a/doegen/doegen.py
+++ b/doegen/doegen.py
@@ -944,7 +944,7 @@ def main(
     print('setup:', setup)
 
     # Calculate number of total possible combinations of all factors:
-    Ncombinations_total = np.product(np.asarray(setup.factor_levels))
+    Ncombinations_total = np.prod(np.asarray(setup.factor_levels))
     print("Number of total combinations (Full Factorial):", Ncombinations_total)
 
     ### Make designs for multiple run sizes:
@@ -1176,7 +1176,7 @@ def full_factorial_design(fname_setup,outfile='full_factorial_design_table.csv')
     design_levels={}
     # how many experiments are there in a full factorial design? print this.
     DoE_setup=ExperimentalSetup.read(fname_setup) 
-    Ncombinations_total = np.product(np.asarray(DoE_setup.factor_levels)) 
+    Ncombinations_total = np.prod(np.asarray(DoE_setup.factor_levels)) 
     print("Generate Full Factorial experiment design table: ",Ncombinations_total," experiments")
 
     #create and fill in the design table with the variable parameters. These are the ones flagged as "Yes" in the input excel file.


### PR DESCRIPTION
This PR addresses an issue caused by the deprecation of `np.product` in NumPy version 1.25 and later. In the current codebase, `np.product` is only used to calculate the total number of possible combinations of factors, so the required modifications are minute. 

As of NumPy 1.25.0, `np.product` has been deprecated, which leads to compatibility issues for projects requiring `numpy>=1.22.0`. For instance, the tests are not run successfully.

**Changes made:**
- Replaced instances of `np.product` with `np.prod`, which is the recommended alternative in NumPy.

**Tests:**
- The existing tests have been executed and pass successfully. No new tests were needed, as this is a straightforward replacement that maintains the same functionality.

**References:**
- [NumPy 1.25.0 Release Notes](https://numpy.org/devdocs/release/1.25.0-notes.html) - Documentation indicating the deprecation of np.product.

Please review the changes and let me know if any additional modifications are required :)

